### PR TITLE
Add dstack to Model Fairness & Privacy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ If you're in a hurry or just don't like reading, here's a podcast-style breakdow
 
 ### Model Fairness & Privacy
 
+* [`Dstack-TEE/dstack`](https://github.com/Dstack-TEE/dstack): TEE framework for private AI model deployment with hardware-level isolation using Intel TDX and NVIDIA Confidential Computing
 * [`fairlearn/fairlearn`](https://github.com/fairlearn/fairlearn): a Python package to assess and improve fairness of ML models
 * [`pytorch/opacus`](https://github.com/pytorch/opacus): a library that enables training PyTorch models with differential privacy
 * [`tensorflow/privacy`](https://github.com/tensorflow/privacy): a library for training ML models with privacy for training data


### PR DESCRIPTION
This PR adds [dstack](https://github.com/Dstack-TEE/dstack) to the **Model Fairness & Privacy** section of the Tools.

**What is dstack?**
dstack is a TEE (Trusted Execution Environment) framework that enables private AI model deployment with hardware-level isolation using Intel TDX and NVIDIA Confidential Computing technologies.

**Why Model Fairness & Privacy?**
- Provides **hardware-level privacy** for AI model deployment
- Complements existing privacy tools (differential privacy, PPML) with infrastructure-level protection
- Enables **confidential AI** workloads in safety-critical environments
- Supports high-performance GPU privacy with NVIDIA Confidential Computing

This addition enhances the privacy toolkit for safety-critical AI practitioners who need strong isolation guarantees for their models.