### PR TITLE
Add Future AGI ai-evaluation to Tools > Model Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,7 @@ If you're in a hurry or just don't like reading, here's a podcast-style breakdow
 ### Model Evaluation
 
 * [`confident-ai/deepeval`](https://github.com/confident-ai/deepeval): a simple-to-use, open-source LLM evaluation framework, for evaluating and testing LLM systems
+* [`future-agi/ai-evaluation`](https://github.com/future-agi/ai-evaluation): an open-source LLM evaluation framework with 50+ metrics, LLM-as-Judge augmentation, and guardrail scanners (jailbreak, PII, prompt-injection); AutoEval pipelines with CI/CD support
 * [`RobustBench/robustbench`](https://github.com/RobustBench/robustbench): a standardized adversarial robustness benchmark
 * [`trust-ai/SafeBench`](https://github.com/trust-ai/SafeBench): a benchmark for evaluating Autonomous Vehicles in safety-critical scenarios
 


### PR DESCRIPTION
## Description

Adds [`future-agi/ai-evaluation`](https://github.com/future-agi/ai-evaluation) (101+ stars, Apache 2.0, active) to the `Tools > Model Evaluation` subsection.

It is an open-source LLM evaluation framework with 50+ metrics, LLM-as-Judge augmentation, and guardrail scanners (jailbreak, PII, prompt-injection); AutoEval pipelines with CI/CD support. Relevant to safety-critical AI where automated regression gates on model outputs are required.

## Checklist

- [x] Tools should have a minimum of 100 stars on GitHub. (101 stars)
- [x] Tools should not be listed in more than one section.
- [x] Tools should not be archived and must have been actively maintained within the last 6 months.
- [x] All contributions are listed in alphabetical order within their respective sections.