### PR TITLE
Add Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ If you're in a hurry or just don't like reading, here's a podcast-style breakdow
 * [`aimhubio/aim`](https://github.com/aimhubio/aim): an easy-to-use and supercharged open-source experiment tracker
 * [`comet-ml/opik`](https://github.com/comet-ml/opik): an open-source platform for evaluating, testing and monitoring LLM applications
 * [`evidentlyai/evidently`](https://github.com/evidentlyai/evidently): an open-source ML and LLM observability framework
+* [`future-agi/future-agi`](https://github.com/future-agi/future-agi): Open-source platform for agent simulation, evaluating, tracing, guarding, and auto-improving AI agents
 * [`IDSIA/sacred`](https://github.com/IDSIA/sacred): a tool to help you configure, organize, log and reproduce experiments
 * [`mlflow/mlflow`](https://github.com/mlflow/mlflow): an open-source platform for the ML lifecycle
 * [`wandb/wandfb`](https://github.com/wandb/wandb): a fully-featured AI developer platform


### PR DESCRIPTION
This PR adds FutureAGI to the Model Evaluation section.

FutureAGI is an open-source platform for evaluating LLM and agent apps. Scores the full agent execution path, not just the final answer. 70+ built-in metrics, multimodal and custom evals, LLM-as-judge, and guardrail scanners behind one evaluate() call. | Apache 2.0 | Self-hostable

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with FutureAGI.